### PR TITLE
Temporary Network Optimizations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-	"rust-analyzer.linkedProjects": [".\\deez_engine\\Cargo.toml"]
+	"rust-analyzer.linkedProjects": [
+		"./deez_engine/Cargo.toml"
+	]
 }


### PR DESCRIPTION
- Removed Block engine forwarding while deez engine maintains upgrades to QUIC.

- Added spoofed forwarding for health metrics on grafana

- Added pattern match on deez engine error types to handle different errors as they should (Ex. Resubscribe only on receiver breaks)

- Added error returning on async threads for forwarding batches -> faster tcp stream detection